### PR TITLE
Only require MRO::Compat for perls before 5.10

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -19,6 +19,8 @@ repository.type   = git
 
 [Prereqs]
 perl        = v5.6
+
+[PerlVersionPrereqs / 5.010]
 MRO::Compat = 0
 
 [Prereqs / TestRequires]


### PR DESCRIPTION
see https://metacpan.org/pod/Dist::Zilla::Plugin::PerlVersionPrereqs